### PR TITLE
Allow alpha numeric track data

### DIFF
--- a/lib/magnet/parser.rb
+++ b/lib/magnet/parser.rb
@@ -1,8 +1,8 @@
 module Magnet
   class Parser
     TRACKS = {
-      1 => /\A%(?<format>[A-Z])(?<pan>[0-9]{1,19})\^(?<name>[A-Za-z.\/ ]{2,26})\^(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]+)\?\Z/,
-      2 => /\A;(?<format>[A-Z])(?<pan>[0-9]{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]+)\?\Z/
+      1 => /\A%(?<format>[A-Z])(?<pan>\w{1,19})\^(?<name>[A-Za-z.\/ ]{2,26})\^(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]+)\?\Z/,
+      2 => /\A;(?<format>[A-Z])(?<pan>\w{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]+)\?\Z/
     }.freeze
 
     def initialize(track = :auto)

--- a/test/magnet/parser_test.rb
+++ b/test/magnet/parser_test.rb
@@ -38,5 +38,15 @@ describe Magnet::Parser do
       assert_equal "321", attributes[:service_code]
       assert_equal "0000000725000000", attributes[:discretionary_data]
     end
+
+    it "should parse sample #4" do
+      parser = Magnet::Parser.new(:auto)
+      attributes = parser.parse("%BA98F462FA7B435C7^GIFT/CARD     ^2001901123?")
+      assert_equal "A98F462FA7B435C7", attributes[:pan]
+      assert_equal "GIFT/CARD     ", attributes[:name]
+      assert_equal "2001", attributes[:expiration]
+      assert_equal "901", attributes[:service_code]
+      assert_equal "123", attributes[:discretionary_data]
+    end
   end
 end


### PR DESCRIPTION
Allow more generic track data: alphanumeric as opposed to numeric.

@samuelkadolph 
