### PR TITLE
Add punctuation to allowable name validations

### DIFF
--- a/lib/magnet/parser.rb
+++ b/lib/magnet/parser.rb
@@ -1,7 +1,7 @@
 module Magnet
   class Parser
     TRACKS = {
-      1 => /\A%(?<format>[A-Z])(?<pan>[0-9 ]{1,19})\^(?<name>[A-Za-z0-9.'&_!@#\$\%*\\~,"\-\/ *]{2,26})\^(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]*)\?\Z/,
+      1 => /\A%(?<format>[A-Z])(?<pan>[0-9 ]{1,19})\^(?<name>[A-Za-z0-9.'&_!@#\$\%*\\~,"\-\/ *]{0,26})\^(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]*)\?\Z/,
       2 => /\A;(?<format>[A-Z])(?<pan>[0-9 ]{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]*)\?\Z/
     }.freeze
 

--- a/test/magnet/parser_test.rb
+++ b/test/magnet/parser_test.rb
@@ -88,6 +88,12 @@ describe Magnet::Parser do
       assert_equal "HAMMOND/G                 ", attributes[:name]
     end
 
+    it "should parse track data with no name" do
+      attributes = @parser.parse("%B4717270000000000^^0000000000000000000000000000000?")
+
+      assert_equal "", attributes[:name]
+    end
+
     it "should parse track data with numbers in the name" do
       attributes = @parser.parse("%B4717270000000000^LLC/TESTING SCENTS5^0000000000000000000000000000000?")
 


### PR DESCRIPTION
# What this does

This adds a lot of punctuation characters to fix issues with parsing real-world track data.

Please review @samuelkadolph @jduff @joshpc @fw42 
