### PR TITLE
Add optional space after carrot to regexp

### DIFF
--- a/lib/magnet/parser.rb
+++ b/lib/magnet/parser.rb
@@ -1,7 +1,7 @@
 module Magnet
   class Parser
     TRACKS = {
-      1 => /\A%(?<format>[A-Z])(?<pan>[0-9 ]{1,19})\^(?<name>[^^]*)\^(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]*)\?\Z/,
+      1 => /\A%(?<format>[A-Z])(?<pan>[0-9 ]{1,19})\^(?<name>[^^]*)\^\s?(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]*)\?\Z/,
       2 => /\A;(?<format>[A-Z])(?<pan>[0-9 ]{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]*)\?\Z/
     }.freeze
 

--- a/test/magnet/parser_test.rb
+++ b/test/magnet/parser_test.rb
@@ -189,5 +189,10 @@ describe Magnet::Parser do
 
       assert_equal "ALISON,MAYNE/B            /", attributes[:name]
     end
+
+    it "should parse track data with space after the second carrot" do
+      attributes = @parser.parse("%B4717270000000000^ALISON MAYNE/B^ 0000000?")
+      assert_equal "ALISON MAYNE/B", attributes[:name]
+    end
   end
 end


### PR DESCRIPTION
Not sure if we should allow only one space or arbitrary many.

@samuelkadolph
