### PR TITLE
Track 2 Support

### DIFF
--- a/lib/magnet/card.rb
+++ b/lib/magnet/card.rb
@@ -49,7 +49,7 @@ module Magnet
         attributes = parser.parse(track_data)
         position1, position2, position3 = (attributes[:service_code] || "").scan(/\d/).map(&:to_i)
         year, month = (attributes[:expiration] || "").scan(/\d\d/).map(&:to_i)
-        title, first_name, initial, last_name = parse_name(attributes[:name].rstrip)
+        title, first_name, initial, last_name = parse_name(attributes[:name].rstrip) if attributes[:name]
 
         card = new
         card.allowed_services = hash_lookup(ALLOWED_SERVICES, position3)

--- a/lib/magnet/parser.rb
+++ b/lib/magnet/parser.rb
@@ -2,7 +2,7 @@ module Magnet
   class Parser
     TRACKS = {
       1 => /\A%(?<format>[A-Z])(?<pan>[0-9 ]{1,19})\^(?<name>[^^]*)\^\s?(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]*)\?\Z/,
-      2 => /\A;(?<format>[A-Z])(?<pan>[0-9 ]{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]*)\?\Z/
+      2 => /\A;(?<pan>[0-9 ]{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]*)\?\Z/,
     }.freeze
 
     def initialize(track = :auto)
@@ -15,13 +15,21 @@ module Magnet
       tracks.each do |track|
         if m = track.match(track_data)
           attributes = {}
-          attributes[:format] = m[:format]
-          attributes[:pan] = m[:pan]
-          attributes[:name] = m[:name]
-          attributes[:expiration] = m[:expiration] == "^" ? nil : m[:expiration]
-          attributes[:service_code] = m[:service_code] == "^" ? nil : m[:service_code]
-          attributes[:discretionary_data] = m[:discretionary_data] == "" ? nil : m[:discretionary_data]
-          return attributes
+          if track == TRACKS[1]
+            attributes[:format] = m[:format]
+            attributes[:pan] = m[:pan]
+            attributes[:name] = m[:name]
+            attributes[:expiration] = m[:expiration] == "^" ? nil : m[:expiration]
+            attributes[:service_code] = m[:service_code] == "^" ? nil : m[:service_code]
+            attributes[:discretionary_data] = m[:discretionary_data] == "" ? nil : m[:discretionary_data]
+            return attributes
+          elsif track == TRACKS[2]
+            attributes[:pan] = m[:pan]
+            attributes[:expiration] = m[:expiration] == "=" ? nil : m[:expiration]
+            attributes[:service_code] = m[:service_code] == "=" ? nil : m[:service_code]
+            attributes[:discretionary_data] = m[:discretionary_data] == "" ? nil : m[:discretionary_data]
+            return attributes
+          end
         end
       end
 

--- a/lib/magnet/version.rb
+++ b/lib/magnet/version.rb
@@ -1,3 +1,3 @@
 module Magnet
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end

--- a/test/magnet/card_parser_test.rb
+++ b/test/magnet/card_parser_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+describe Magnet::Card do
+  describe "Parse" do
+    before do
+      @parser = Magnet::Parser.new(:auto)
+    end
+
+    it "track 2 should work" do
+      track_data = ";4716916000001234=1809901123?"
+      card = Magnet::Card.parse(track_data, @parser)
+      assert_equal "4716916000001234", card.number
+      assert_equal :no_restrictions, card.allowed_services
+      assert_equal :normal, card.authorization_processing
+      assert_equal "123", card.discretionary_data
+      assert_equal 9, card.expiration_month
+      assert_equal 18, card.expiration_year
+      assert_equal :test, card.interchange
+      assert_nil card.first_name
+      assert_nil card.format
+      assert_nil card.initial
+      assert_nil card.last_name
+      assert_nil card.pin_requirements
+      assert_nil card.technology
+      assert_nil card.title
+    end
+
+    it "track 1 should work" do
+      track_data = "%B5452300551227189^HOGAN/PAUL      ^08043210000000725000000?"
+      card = Magnet::Card.parse(track_data, @parser)
+      assert_equal "5452300551227189", card.number
+      assert_equal :no_restrictions, card.allowed_services
+      assert_equal :by_issuer, card.authorization_processing
+      assert_equal "0000000725000000", card.discretionary_data
+      assert_equal 4, card.expiration_month
+      assert_equal 8, card.expiration_year
+      assert_nil card.interchange
+      assert_equal "PAUL", card.first_name
+      assert_equal :bank, card.format
+      assert_nil card.initial
+      assert_equal "HOGAN", card.last_name
+      assert_nil card.pin_requirements
+      assert_nil card.technology
+      assert_nil card.title
+    end
+  end
+end

--- a/test/magnet/parser_test.rb
+++ b/test/magnet/parser_test.rb
@@ -6,33 +6,6 @@ describe Magnet::Parser do
       @parser = Magnet::Parser.new(1)
     end
 
-    it "should parse track 2 data sample #1" do
-      attributes = @parser.parse(";4716916000001234=1809901123?")
-
-      assert_equal "4716916000001234", attributes[:pan]
-      assert_equal "1809", attributes[:expiration]
-      assert_equal "901", attributes[:service_code]
-      assert_equal "123", attributes[:discretionary_data]
-    end
-
-    it "should parse track 2 data sample #2" do
-      attributes = @parser.parse(";5301250070000191=08051010912345678901?")
-
-      assert_equal "5301250070000191", attributes[:pan]
-      assert_equal "0805", attributes[:expiration]
-      assert_equal "101", attributes[:service_code]
-      assert_equal "0912345678901", attributes[:discretionary_data]
-    end
-
-    it "should parse track 2 data sample #3" do
-      attributes = @parser.parse(";3540599999991047=080501234567?")
-
-      assert_equal "3540599999991047", attributes[:pan]
-      assert_equal "0805", attributes[:expiration]
-      assert_equal "012", attributes[:service_code]
-      assert_equal "34567", attributes[:discretionary_data]
-    end
-
     it "should parse sample #1" do
       attributes = @parser.parse("%B6011898748579348^DOE/ JOHN              ^37829821000123456789?")
 
@@ -220,6 +193,38 @@ describe Magnet::Parser do
     it "should parse track data with space after the second carrot" do
       attributes = @parser.parse("%B4717270000000000^ALISON MAYNE/B^ 0000000?")
       assert_equal "ALISON MAYNE/B", attributes[:name]
+    end
+  end
+
+  describe "Track 2" do
+    before do
+      @parser = Magnet::Parser.new(2)
+    end
+      it "should parse track 2 data sample #1" do
+      attributes = @parser.parse(";4716916000001234=1809901123?")
+
+      assert_equal "4716916000001234", attributes[:pan]
+      assert_equal "1809", attributes[:expiration]
+      assert_equal "901", attributes[:service_code]
+      assert_equal "123", attributes[:discretionary_data]
+    end
+
+    it "should parse track 2 data sample #2" do
+      attributes = @parser.parse(";5301250070000191=08051010912345678901?")
+
+      assert_equal "5301250070000191", attributes[:pan]
+      assert_equal "0805", attributes[:expiration]
+      assert_equal "101", attributes[:service_code]
+      assert_equal "0912345678901", attributes[:discretionary_data]
+    end
+
+    it "should parse track 2 data sample #3" do
+      attributes = @parser.parse(";3540599999991047=080501234567?")
+
+      assert_equal "3540599999991047", attributes[:pan]
+      assert_equal "0805", attributes[:expiration]
+      assert_equal "012", attributes[:service_code]
+      assert_equal "34567", attributes[:discretionary_data]
     end
   end
 end

--- a/test/magnet/parser_test.rb
+++ b/test/magnet/parser_test.rb
@@ -6,6 +6,33 @@ describe Magnet::Parser do
       @parser = Magnet::Parser.new(1)
     end
 
+    it "should parse track 2 data sample #1" do
+      attributes = @parser.parse(";4716916000001234=1809901123?")
+
+      assert_equal "4716916000001234", attributes[:pan]
+      assert_equal "1809", attributes[:expiration]
+      assert_equal "901", attributes[:service_code]
+      assert_equal "123", attributes[:discretionary_data]
+    end
+
+    it "should parse track 2 data sample #2" do
+      attributes = @parser.parse(";5301250070000191=08051010912345678901?")
+
+      assert_equal "5301250070000191", attributes[:pan]
+      assert_equal "0805", attributes[:expiration]
+      assert_equal "101", attributes[:service_code]
+      assert_equal "0912345678901", attributes[:discretionary_data]
+    end
+
+    it "should parse track 2 data sample #3" do
+      attributes = @parser.parse(";3540599999991047=080501234567?")
+
+      assert_equal "3540599999991047", attributes[:pan]
+      assert_equal "0805", attributes[:expiration]
+      assert_equal "012", attributes[:service_code]
+      assert_equal "34567", attributes[:discretionary_data]
+    end
+
     it "should parse sample #1" do
       attributes = @parser.parse("%B6011898748579348^DOE/ JOHN              ^37829821000123456789?")
 


### PR DESCRIPTION
Magnet was failing to parse track 2 data because they don't have format codes or names.

@davidseal @abecevello 