### PR TITLE
Ignore checksum at end of track 2

### DIFF
--- a/lib/magnet/parser.rb
+++ b/lib/magnet/parser.rb
@@ -2,7 +2,7 @@ module Magnet
   class Parser
     TRACKS = {
       1 => /\A%(?<format>[A-Z])(?<pan>[0-9 ]{1,19})\^(?<name>[^^]*)\^\s?(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]*)\?\Z/,
-      2 => /\A;(?<pan>[0-9 ]{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]*)\?\Z/,
+      2 => /\A;(?<pan>[0-9 ]{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]*)\?.?\Z/,
     }.freeze
 
     def initialize(track = :auto)

--- a/lib/magnet/version.rb
+++ b/lib/magnet/version.rb
@@ -1,3 +1,3 @@
 module Magnet
-  VERSION = "1.5.1"
+  VERSION = "1.5.2"
 end

--- a/test/magnet/parser_test.rb
+++ b/test/magnet/parser_test.rb
@@ -226,5 +226,14 @@ describe Magnet::Parser do
       assert_equal "012", attributes[:service_code]
       assert_equal "34567", attributes[:discretionary_data]
     end
+
+    it "should ignore checksum when parsing track 2" do
+      attributes = @parser.parse(";5413330089020037=1412101050930812??")
+
+      assert_equal "5413330089020037", attributes[:pan]
+      assert_equal "1412", attributes[:expiration]
+      assert_equal "101", attributes[:service_code]
+      assert_equal "050930812", attributes[:discretionary_data]
+    end
   end
 end


### PR DESCRIPTION
Updates the track parser to ignore the checksum at the end of track 2.

@ryanbalsdon @davidseal 