### PR TITLE
Add EMV track 2 parsing support

### DIFF
--- a/lib/magnet/parser.rb
+++ b/lib/magnet/parser.rb
@@ -3,6 +3,7 @@ module Magnet
     TRACKS = {
       1 => /\A%(?<format>[A-Z])(?<pan>[0-9 ]{1,19})\^(?<name>[^^]*)\^\s?(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]*)\?\Z/,
       2 => /\A;(?<pan>[0-9 ]{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]*)\?.?\Z/,
+      'EMV' => /\A(?<pan>[0-9 ]{1,19})(d|D)(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?fF]*)(f|F)?\Z/,
     }.freeze
 
     def initialize(track = :auto)
@@ -23,7 +24,7 @@ module Magnet
             attributes[:service_code] = m[:service_code] == "^" ? nil : m[:service_code]
             attributes[:discretionary_data] = m[:discretionary_data] == "" ? nil : m[:discretionary_data]
             return attributes
-          elsif track == TRACKS[2]
+          elsif track == TRACKS[2] || track == TRACKS['EMV']
             attributes[:pan] = m[:pan]
             attributes[:expiration] = m[:expiration] == "=" ? nil : m[:expiration]
             attributes[:service_code] = m[:service_code] == "=" ? nil : m[:service_code]

--- a/test/magnet/card_parser_test.rb
+++ b/test/magnet/card_parser_test.rb
@@ -43,5 +43,24 @@ describe Magnet::Card do
       assert_nil card.technology
       assert_nil card.title
     end
+
+    it "EMV track 2 should work" do
+      track_data = "5213320039019055d2512620062930423f"
+      card = Magnet::Card.parse(track_data, @parser)
+      assert_equal "5213320039019055", card.number
+      assert_equal :no_restrictions, card.allowed_services
+      assert_equal :by_issuer, card.authorization_processing
+      assert_equal "062930423", card.discretionary_data
+      assert_equal 12, card.expiration_month
+      assert_equal 25, card.expiration_year
+      assert_equal :national, card.interchange
+      assert_equal :integrated_circuit_card, card.technology
+      assert_equal :pin_required, card.pin_requirements
+      assert_nil card.first_name
+      assert_nil card.format
+      assert_nil card.initial
+      assert_nil card.last_name
+      assert_nil card.title
+    end
   end
 end


### PR DESCRIPTION
### Description
This adds support for EMV track 2 data parsing to the magnet gem. EMV Track 2 found contains the data elements of track 2 according to ISO/IEC 7813, excluding start sentinel, end sentinel, and Longitudinal Redundancy Check (LRC).

cc/ @bizla @ryanbalsdon @abecevello 