### PR TITLE
Exposing the track_format used to parse the track

### DIFF
--- a/lib/magnet/card.rb
+++ b/lib/magnet/card.rb
@@ -42,10 +42,10 @@ module Magnet
       6 => :integrated_circuit_card
     }.freeze
 
-    attr_accessor :allowed_services, :authorization_processing, :discretionary_data, :expiration_year, :expiration_month, :first_name, :format, :initial, :interchange, :last_name, :number, :pin_requirements, :technology, :title
+    attr_accessor :allowed_services, :authorization_processing, :discretionary_data, :expiration_year, :expiration_month, :first_name, :format, :initial, :interchange, :last_name, :number, :pin_requirements, :technology, :title, :track_format
 
     class << self
-      def parse(track_data, parser = Parser.new(:auto))
+      def parse(track_data, parser = Parser.new())
         attributes = parser.parse(track_data)
         position1, position2, position3 = (attributes[:service_code] || "").scan(/\d/).map(&:to_i)
         year, month = (attributes[:expiration] || "").scan(/\d\d/).map(&:to_i)
@@ -66,6 +66,7 @@ module Magnet
         card.pin_requirements = hash_lookup(PIN_REQUIREMENTS, position3)
         card.technology = hash_lookup(TECHNOLOGY, position1)
         card.title = title
+        card.track_format = attributes[:track_format]
         card
       end
 

--- a/lib/magnet/parser.rb
+++ b/lib/magnet/parser.rb
@@ -3,34 +3,26 @@ module Magnet
     TRACKS = {
       1 => /\A%(?<format>[A-Z])(?<pan>[0-9 ]{1,19})\^(?<name>[^^]*)\^\s?(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]*)\?\Z/,
       2 => /\A;(?<pan>[0-9 ]{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]*)\?.?\Z/,
-      'EMV' => /\A(?<pan>[0-9 ]{1,19})(d|D)(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?fF]*)(f|F)?\Z/,
+      :emv => /\A(?<pan>[0-9 ]{1,19})(d|D)(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?fF]*)(f|F)?\Z/,
     }.freeze
 
-    def initialize(track = :auto)
-      @track = :auto
-    end
-
     def parse(track_data)
-      tracks = @track == :auto ? TRACKS.values : [TRACKS[@track]]
-
-      tracks.each do |track|
+      TRACKS.each do |track_format, track|
         if m = track.match(track_data)
           attributes = {}
-          if track == TRACKS[1]
+          attributes[:track_format] = track_format
+          attributes[:pan] = m[:pan]
+          attributes[:discretionary_data] = m[:discretionary_data].empty? ? nil : m[:discretionary_data]
+          if track_format == 1
             attributes[:format] = m[:format]
-            attributes[:pan] = m[:pan]
             attributes[:name] = m[:name]
             attributes[:expiration] = m[:expiration] == "^" ? nil : m[:expiration]
             attributes[:service_code] = m[:service_code] == "^" ? nil : m[:service_code]
-            attributes[:discretionary_data] = m[:discretionary_data] == "" ? nil : m[:discretionary_data]
-            return attributes
-          elsif track == TRACKS[2] || track == TRACKS['EMV']
-            attributes[:pan] = m[:pan]
+          elsif track_format == 2 || track_format == :emv
             attributes[:expiration] = m[:expiration] == "=" ? nil : m[:expiration]
             attributes[:service_code] = m[:service_code] == "=" ? nil : m[:service_code]
-            attributes[:discretionary_data] = m[:discretionary_data] == "" ? nil : m[:discretionary_data]
-            return attributes
           end
+          return attributes
         end
       end
 

--- a/lib/magnet/version.rb
+++ b/lib/magnet/version.rb
@@ -1,3 +1,3 @@
 module Magnet
-  VERSION = "1.6.0"
+  VERSION = "1.7.0"
 end

--- a/test/magnet/card_parser_test.rb
+++ b/test/magnet/card_parser_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 describe Magnet::Card do
   describe "Parse" do
     before do
-      @parser = Magnet::Parser.new(:auto)
+      @parser = Magnet::Parser.new()
     end
 
     it "track 2 should work" do
@@ -23,6 +23,7 @@ describe Magnet::Card do
       assert_nil card.pin_requirements
       assert_nil card.technology
       assert_nil card.title
+      assert_equal 2, card.track_format
     end
 
     it "track 1 should work" do
@@ -42,6 +43,7 @@ describe Magnet::Card do
       assert_nil card.pin_requirements
       assert_nil card.technology
       assert_nil card.title
+      assert_equal 1, card.track_format
     end
 
     it "EMV track 2 should work" do
@@ -61,6 +63,14 @@ describe Magnet::Card do
       assert_nil card.initial
       assert_nil card.last_name
       assert_nil card.title
+      assert_equal :emv, card.track_format
+    end
+
+    it "should work without a memoized parser" do
+      track_data = "%B5452300551227189^HOGAN/PAUL      ^08043210000000725000000?"
+      card_with_parser = Magnet::Card.parse(track_data, @parser)
+      card_without_parser = Magnet::Card.parse(track_data)
+      assert_equal card_with_parser.number, card_without_parser.number
     end
   end
 end

--- a/test/magnet/parser_test.rb
+++ b/test/magnet/parser_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 describe Magnet::Parser do
   describe "Track 1" do
     before do
-      @parser = Magnet::Parser.new(1)
+      @parser = Magnet::Parser.new()
     end
 
     it "should parse sample #1" do
@@ -15,6 +15,7 @@ describe Magnet::Parser do
       assert_equal "3782", attributes[:expiration]
       assert_equal "982", attributes[:service_code]
       assert_equal "1000123456789", attributes[:discretionary_data]
+      assert_equal 1, attributes[:track_format]
     end
 
     it "should parse sample #2" do
@@ -26,6 +27,7 @@ describe Magnet::Parser do
       assert_equal nil, attributes[:expiration]
       assert_equal nil, attributes[:service_code]
       assert_equal "0000000      00998000000", attributes[:discretionary_data]
+      assert_equal 1, attributes[:track_format]
     end
 
     it "should parse sample #3" do
@@ -37,6 +39,7 @@ describe Magnet::Parser do
       assert_equal "0804", attributes[:expiration]
       assert_equal "321", attributes[:service_code]
       assert_equal "0000000725000000", attributes[:discretionary_data]
+      assert_equal 1, attributes[:track_format]
     end
 
     it "should parse without discretionary data" do
@@ -198,15 +201,17 @@ describe Magnet::Parser do
 
   describe "Track 2" do
     before do
-      @parser = Magnet::Parser.new(2)
+      @parser = Magnet::Parser.new()
     end
-      it "should parse track 2 data sample #1" do
+    
+    it "should parse track 2 data sample #1" do
       attributes = @parser.parse(";4716916000001234=1809901123?")
 
       assert_equal "4716916000001234", attributes[:pan]
       assert_equal "1809", attributes[:expiration]
       assert_equal "901", attributes[:service_code]
       assert_equal "123", attributes[:discretionary_data]
+      assert_equal 2, attributes[:track_format]
     end
 
     it "should parse track 2 data sample #2" do
@@ -216,6 +221,7 @@ describe Magnet::Parser do
       assert_equal "0805", attributes[:expiration]
       assert_equal "101", attributes[:service_code]
       assert_equal "0912345678901", attributes[:discretionary_data]
+      assert_equal 2, attributes[:track_format]
     end
 
     it "should parse track 2 data sample #3" do
@@ -225,6 +231,7 @@ describe Magnet::Parser do
       assert_equal "0805", attributes[:expiration]
       assert_equal "012", attributes[:service_code]
       assert_equal "34567", attributes[:discretionary_data]
+      assert_equal 2, attributes[:track_format]
     end
 
     it "should ignore checksum when parsing track 2" do
@@ -234,6 +241,81 @@ describe Magnet::Parser do
       assert_equal "1412", attributes[:expiration]
       assert_equal "101", attributes[:service_code]
       assert_equal "050930812", attributes[:discretionary_data]
+      assert_equal 2, attributes[:track_format]
+    end
+  end
+
+  describe "EMV" do
+    before do
+      @parser = Magnet::Parser.new()
+    end
+    
+    it "should parse track 2 data sample #1" do
+      attributes = @parser.parse("4716916000001234D18099011234")
+
+      assert_equal "4716916000001234", attributes[:pan]
+      assert_equal "1809", attributes[:expiration]
+      assert_equal "901", attributes[:service_code]
+      assert_equal "1234", attributes[:discretionary_data]
+      assert_equal :emv, attributes[:track_format]
+    end
+
+    it "should parse track 2 data sample #2" do
+      attributes = @parser.parse("5301250070000191D08051010912345678901F")
+
+      assert_equal "5301250070000191", attributes[:pan]
+      assert_equal "0805", attributes[:expiration]
+      assert_equal "101", attributes[:service_code]
+      assert_equal "0912345678901", attributes[:discretionary_data]
+      assert_equal :emv, attributes[:track_format]
+    end
+
+    it "should parse track 2 data sample #3" do
+      attributes = @parser.parse("3540599999991047D080501234567F")
+
+      assert_equal "3540599999991047", attributes[:pan]
+      assert_equal "0805", attributes[:expiration]
+      assert_equal "012", attributes[:service_code]
+      assert_equal "34567", attributes[:discretionary_data]
+      assert_equal :emv, attributes[:track_format]
+    end
+  end
+
+  describe "auto" do
+    before do
+      @parser = Magnet::Parser.new()
+    end
+
+    it "should parse track 1" do
+      attributes = @parser.parse("%B6011898748579348^DOE/ JOHN              ^37829821000123456789?")
+
+      assert_equal "B", attributes[:format]
+      assert_equal "6011898748579348", attributes[:pan]
+      assert_equal "DOE/ JOHN              ", attributes[:name]
+      assert_equal "3782", attributes[:expiration]
+      assert_equal "982", attributes[:service_code]
+      assert_equal "1000123456789", attributes[:discretionary_data]
+      assert_equal 1, attributes[:track_format]
+    end
+
+    it "should parse track 2" do
+      attributes = @parser.parse(";4716916000001234=1809901123?")
+
+      assert_equal "4716916000001234", attributes[:pan]
+      assert_equal "1809", attributes[:expiration]
+      assert_equal "901", attributes[:service_code]
+      assert_equal "123", attributes[:discretionary_data]
+      assert_equal 2, attributes[:track_format]
+    end
+
+    it "should parse emv tracks" do
+      attributes = @parser.parse("4716916000001234D18099011234")
+
+      assert_equal "4716916000001234", attributes[:pan]
+      assert_equal "1809", attributes[:expiration]
+      assert_equal "901", attributes[:service_code]
+      assert_equal "1234", attributes[:discretionary_data]
+      assert_equal :emv, attributes[:track_format]
     end
   end
 end


### PR DESCRIPTION
Review please @bizla @datwelk 

This is needed for a payments processor who must be explicitly told what track they are receiving.