### PR TITLE
Allow EMV track start sentinel in EMV format

### DIFF
--- a/lib/magnet/parser.rb
+++ b/lib/magnet/parser.rb
@@ -3,7 +3,7 @@ module Magnet
     TRACKS = {
       1 => /\A%(?<format>[A-Z])(?<pan>[0-9 ]{1,19})\^(?<name>[^^]*)\^\s?(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]*)\?\Z/,
       2 => /\A;(?<pan>[0-9 ]{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]*)\?.?\Z/,
-      :emv => /\A(?<pan>[0-9 ]{1,19})(d|D)(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?fF]*)(f|F)?\Z/,
+      :emv => /\AB?(?<pan>[0-9 ]{1,19})(d|D)(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?fF]*)(f|F)?\Z/,
     }.freeze
 
     def parse(track_data)

--- a/lib/magnet/parser.rb
+++ b/lib/magnet/parser.rb
@@ -3,7 +3,7 @@ module Magnet
     TRACKS = {
       1 => /\A%(?<format>[A-Z])(?<pan>[0-9 ]{1,19})\^(?<name>[^^]*)\^\s?(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]*)\?\Z/,
       2 => /\A;(?<pan>[0-9 ]{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]*)\?.?\Z/,
-      :emv => /\AB?(?<pan>[0-9 ]{1,19})(d|D)(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?fF]*)(f|F)?\Z/,
+      :emv => /\AB?(?<pan>[0-9 ]{1,19})(d|D)(?<expiration>\d{4}|(d|D))(?<service_code>\d{3}|(d|D))(?<discretionary_data>[^\?fF]*)(f|F)?0?.*\Z/,
     }.freeze
 
     def parse(track_data)

--- a/lib/magnet/version.rb
+++ b/lib/magnet/version.rb
@@ -1,3 +1,3 @@
 module Magnet
-  VERSION = "1.7.0"
+  VERSION = "1.8.0"
 end

--- a/test/magnet/parser_test.rb
+++ b/test/magnet/parser_test.rb
@@ -250,7 +250,7 @@ describe Magnet::Parser do
       @parser = Magnet::Parser.new()
     end
     
-    it "should parse track 2 data sample #1" do
+    it "should parse emv track data sample #1" do
       attributes = @parser.parse("4716916000001234D18099011234")
 
       assert_equal "4716916000001234", attributes[:pan]
@@ -260,7 +260,7 @@ describe Magnet::Parser do
       assert_equal :emv, attributes[:track_format]
     end
 
-    it "should parse track 2 data sample #2" do
+    it "should parse emv track data sample #2" do
       attributes = @parser.parse("5301250070000191D08051010912345678901F")
 
       assert_equal "5301250070000191", attributes[:pan]
@@ -270,8 +270,18 @@ describe Magnet::Parser do
       assert_equal :emv, attributes[:track_format]
     end
 
-    it "should parse track 2 data sample #3" do
+    it "should parse emv track data sample #3" do
       attributes = @parser.parse("3540599999991047D080501234567F")
+
+      assert_equal "3540599999991047", attributes[:pan]
+      assert_equal "0805", attributes[:expiration]
+      assert_equal "012", attributes[:service_code]
+      assert_equal "34567", attributes[:discretionary_data]
+      assert_equal :emv, attributes[:track_format]
+    end
+
+    it "should parse emv track data sample with start sentinel" do
+      attributes = @parser.parse("B3540599999991047D080501234567F")
 
       assert_equal "3540599999991047", attributes[:pan]
       assert_equal "0805", attributes[:expiration]

--- a/test/magnet/parser_test.rb
+++ b/test/magnet/parser_test.rb
@@ -289,6 +289,16 @@ describe Magnet::Parser do
       assert_equal "34567", attributes[:discretionary_data]
       assert_equal :emv, attributes[:track_format]
     end
+
+    it "should parse emv track data sample with trailing zeroes" do
+      attributes = @parser.parse("B3540599999991047D080501234567F000000000000")
+
+      assert_equal "3540599999991047", attributes[:pan]
+      assert_equal "0805", attributes[:expiration]
+      assert_equal "012", attributes[:service_code]
+      assert_equal "34567", attributes[:discretionary_data]
+      assert_equal :emv, attributes[:track_format]
+    end
   end
 
   describe "auto" do


### PR DESCRIPTION
Some EMV readers give track data from swipes with the start sentinel that is normally used for EMV. This adds an optional start sentinel to the track parser for the EMV format to allow this type of track data to be parsed.

Please review @ryanbalsdon @bizla 
