### PR TITLE
Properly Handle Track1 With a Checksum

### DIFF
--- a/lib/magnet/parser.rb
+++ b/lib/magnet/parser.rb
@@ -1,7 +1,7 @@
 module Magnet
   class Parser
     TRACKS = {
-      1 => /\A%(?<format>[A-Z])(?<pan>[0-9 ]{1,19})\^(?<name>[^^]*)\^\s?(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]*)\?\Z/,
+      1 => /\A%(?<format>[A-Z])(?<pan>[0-9 ]{1,19})\^(?<name>[^^]*)\^\s?(?<expiration>\d{4}|\^)(?<service_code>\d{3}|\^)(?<discretionary_data>[^\?]*)\?.?\Z/,
       2 => /\A;(?<pan>[0-9 ]{1,19})=(?<expiration>\d{4}|=)(?<service_code>\d{3}|=)(?<discretionary_data>[^\?]*)\?.?\Z/,
       :emv => /\AB?(?<pan>[0-9 ]{1,19})(d|D)(?<expiration>\d{4}|(d|D))(?<service_code>\d{3}|(d|D))(?<discretionary_data>[^\?fF]*)(f|F)?0?.*\Z/,
     }.freeze

--- a/test/magnet/parser_test.rb
+++ b/test/magnet/parser_test.rb
@@ -18,6 +18,18 @@ describe Magnet::Parser do
       assert_equal 1, attributes[:track_format]
     end
 
+    it "should ignore checksum when parsing track 1" do
+      attributes = @parser.parse("%B6011898748579348^DOE/ JOHN              ^37829821000123456789??")
+
+      assert_equal "B", attributes[:format]
+      assert_equal "6011898748579348", attributes[:pan]
+      assert_equal "DOE/ JOHN              ", attributes[:name]
+      assert_equal "3782", attributes[:expiration]
+      assert_equal "982", attributes[:service_code]
+      assert_equal "1000123456789", attributes[:discretionary_data]
+      assert_equal 1, attributes[:track_format]
+    end
+
     it "should parse sample #2" do
       attributes = @parser.parse("%B6011785948493759^DOE/JOHN L                ^^^0000000      00998000000?")
 


### PR DESCRIPTION
According to the ISO-7813 specification, it is valid for both track 1 and track 2 to end with an optional single character checksum (the LRC, or longitudinal redundancy checksum). Updated the parser to properly handle it for track 1 as it already does for track 2.