### PR TITLE
Expose service code in Card class

### DIFF
--- a/lib/magnet/card.rb
+++ b/lib/magnet/card.rb
@@ -42,7 +42,7 @@ module Magnet
       6 => :integrated_circuit_card
     }.freeze
 
-    attr_accessor :allowed_services, :authorization_processing, :discretionary_data, :expiration_year, :expiration_month, :first_name, :format, :initial, :interchange, :last_name, :number, :pin_requirements, :technology, :title, :track_format
+    attr_accessor :allowed_services, :authorization_processing, :discretionary_data, :expiration_year, :expiration_month, :first_name, :format, :initial, :interchange, :last_name, :number, :pin_requirements, :technology, :title, :track_format, :service_code
 
     class << self
       def parse(track_data, parser = Parser.new())
@@ -67,6 +67,7 @@ module Magnet
         card.technology = hash_lookup(TECHNOLOGY, position1)
         card.title = title
         card.track_format = attributes[:track_format]
+        card.service_code = attributes[:service_code]
         card
       end
 

--- a/test/magnet/card_test.rb
+++ b/test/magnet/card_test.rb
@@ -26,6 +26,7 @@ describe Magnet::Card do
       assert_equal nil, card.pin_requirements
       assert_equal nil, card.technology
       assert_equal nil, card.title
+      assert_equal "321", card.service_code
     end
 
     it "should parse an initial" do


### PR DESCRIPTION
This change intends to expose the service code as part of the `Magnet::Card` class.

The Parser returns this value in the attributes that are returned, which is then subsequently used to derive some information, but the actual value also seemed useful to expose without having to create a separate instance of the Parser class to retrieve.